### PR TITLE
Fix syntax error

### DIFF
--- a/src/PaletteStore.ts
+++ b/src/PaletteStore.ts
@@ -9,7 +9,7 @@
  * https://github.com/inclusive-design/adaptive-palette/blob/main/LICENSE
  */
 
-import { JsonPaletteType } from "./index.d";
+import { JsonPaletteType, PaletteFileMapType } from "./index.d";
 
 export class PaletteStore {
 
@@ -19,7 +19,7 @@ export class PaletteStore {
   static paletteMap = {};
 
   // Singleton map of palette names and their files.
-  static paletteFileMap; PaletteFileMapType = {};
+  static paletteFileMap: PaletteFileMapType = {};
 
   /**
    * Report if the PaletteStore is empty.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -46,6 +46,5 @@ export type EncodingType = BlissSymbolInfoType & {
 };
 
 export type PaletteFileMapType = {
-  paletteName: string,
-  filePath: string
+  [paletteName: string, filePath: string]
 }


### PR DESCRIPTION
There is a static member declaration, `paletteFileMap`, in the class `PaletteStore` where the intent was to declare it as  type `PaletteFileMapType`.  However, `paletteFileMap` is followed by a semi-colon instead of a colon.

This PR changes the semi-colon to a colon, and makes related modifications so that the `PaletteFileMapType` is used correctly.
