### PR TITLE
feat: separate output area from symbol palettes

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,13 +8,13 @@
   </head>
   <body>
     <h2>Palettes Based on JSON</h1>
-    <div id="outputArea">
-      <div id="output_palette"></div>
-    </div>
     <div id="backupArea">
       <div id="backup_palette"></div>
     </div>
-    <div id="mainPaletteDisplayArea">
+    <div id="outputArea">
+      <div id="output_palette"></div>
+    </div>
+   <div id="mainPaletteDisplayArea">
       <script type="module">
         import "./src/index.js";
       </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "adaptive-palette",
       "dependencies": {
+        "@preact/signals": "^1.2.3",
         "bliss-svg-builder": "^0.1.0-alpha.4",
         "htm": "^3.1.1",
         "preact": "^10.13.1",
@@ -3163,6 +3164,30 @@
       "peerDependencies": {
         "@babel/core": "7.x",
         "vite": "2.x || 3.x || 4.x || 5.x"
+      }
+    },
+    "node_modules/@preact/signals": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.2.3.tgz",
+      "integrity": "sha512-M2DXse3Wi8HwjI1d2vQWOLJ3lHogvqTsJYvl4ofXRXgMFQzJ7kmlZvlt5i8x5S5VwgZu0ghru4HkLqOoFfU2JQ==",
+      "dependencies": {
+        "@preact/signals-core": "^1.6.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact": "10.x"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.6.0.tgz",
+      "integrity": "sha512-O/XGxwP85h1F7+ouqTMOIZ3+V1whfaV9ToIVcuyGriD4JkSD00cQo54BKdqjvBJxbenvp7ynfqRHEwI6e+NIhw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/@prefresh/babel-plugin": {
@@ -11127,9 +11152,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
-      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
+      "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@preact/signals": "^1.2.3",
     "bliss-svg-builder": "^0.1.0-alpha.4",
     "htm": "^3.1.1",
     "preact": "^10.13.1",

--- a/src/ActionBmwCodeCell.ts
+++ b/src/ActionBmwCodeCell.ts
@@ -13,7 +13,7 @@ import { VNode } from "preact";
 import { html } from "htm/preact";
 import { BlissSymbolInfoType, LayoutInfoType } from "./index.d";
 import { BlissSymbol } from "./BlissSymbol";
-import { usePaletteState } from "./GlobalData";
+import { changeEncodingContents } from "./GlobalData";
 import { generateGridStyle, speak } from "./GlobalUtils";
 import "./ActionBmwCodeCell.scss";
 
@@ -24,8 +24,6 @@ type ActionBmwCodeCellPropsType = {
 };
 
 export function ActionBmwCodeCell (props: ActionBmwCodeCellPropsType): VNode {
-  const paletteState = usePaletteState();
-
   const {
     columnStart, columnSpan, rowStart, rowSpan, bciAvId, label
   } = props.options;
@@ -38,8 +36,7 @@ export function ActionBmwCodeCell (props: ActionBmwCodeCellPropsType): VNode {
       "label": props.options.label,
       "bciAvId": props.options.bciAvId
     };
-    const fullEncoding = paletteState.fullEncoding;
-    paletteState.setFullEncoding([...fullEncoding, payload]);
+    changeEncodingContents.value = [...changeEncodingContents.value, payload];
     speak(props.options.label);
   };
 

--- a/src/CommandClearEncoding.ts
+++ b/src/CommandClearEncoding.ts
@@ -12,7 +12,7 @@
 import { VNode } from "preact";
 import { html } from "htm/preact";
 import { BlissSymbol } from "./BlissSymbol";
-import { usePaletteState } from "./GlobalData";
+import { changeEncodingContents } from "./GlobalData";
 import { BlissSymbolInfoType, LayoutInfoType } from "./index.d";
 import { generateGridStyle, speak } from "./GlobalUtils";
 
@@ -27,13 +27,10 @@ export function CommandClearEncoding (props: CommandClearEncodingProps): VNode {
   const { id, options } = props;
   const { label, bciAvId, columnStart, columnSpan, rowStart, rowSpan, ariaControls } = options;
 
-  const paletteState = usePaletteState();
-  const setFullEncoding = paletteState?.setFullEncoding;
-
   const gridStyles = generateGridStyle(columnStart, columnSpan, rowStart, rowSpan);
 
   const cellClicked = (): void => {
-    setFullEncoding([]);
+    changeEncodingContents.value = [];
     speak(label);
   };
 

--- a/src/CommandDelLastEncoding.ts
+++ b/src/CommandDelLastEncoding.ts
@@ -12,7 +12,7 @@
 import { VNode } from "preact";
 import { html } from "htm/preact";
 import { BlissSymbol } from "./BlissSymbol";
-import { usePaletteState } from "./GlobalData";
+import { changeEncodingContents } from "./GlobalData";
 import { BlissSymbolInfoType, LayoutInfoType } from "./index.d";
 import { generateGridStyle, speak } from "./GlobalUtils";
 
@@ -27,14 +27,12 @@ export function CommandDelLastEncoding (props: CommandDelLastEncodingProps): VNo
   const { id, options } = props;
   const { label, bciAvId, columnStart, columnSpan, rowStart, rowSpan, ariaControls } = options;
 
-  const paletteState = usePaletteState();
-
   const gridStyles = generateGridStyle(columnStart, columnSpan, rowStart, rowSpan);
 
   const cellClicked = (): void => {
-    const newEncoding = [...paletteState.fullEncoding];
-    newEncoding.pop();
-    paletteState.setFullEncoding(newEncoding);
+    const newEncodingContents = [...changeEncodingContents.value];
+    newEncodingContents.pop();
+    changeEncodingContents.value = newEncodingContents;
     speak(label);
   };
 

--- a/src/ContentBmwEncoding.ts
+++ b/src/ContentBmwEncoding.ts
@@ -12,7 +12,7 @@
 import { VNode } from "preact";
 import { html } from "htm/preact";
 import { BlissSymbol } from "./BlissSymbol";
-import { usePaletteState } from "./GlobalData";
+import { changeEncodingContents } from "./GlobalData";
 import { ContentBmwEncodingType } from "./index.d";
 import { generateGridStyle } from "./GlobalUtils";
 import "./ContentBmwEncoding.scss";
@@ -23,8 +23,6 @@ type ContentBmwEncodingProps = {
 }
 
 export function ContentBmwEncoding (props: ContentBmwEncodingProps): VNode {
-  const paletteState = usePaletteState();
-
   const { id, options } = props;
   const { columnStart, columnSpan, rowStart, rowSpan } = options;
 
@@ -32,7 +30,7 @@ export function ContentBmwEncoding (props: ContentBmwEncodingProps): VNode {
 
   return html`
     <div id="${id}" class="bmwEncodingArea" role="textbox" aria-label="Input Area" aria-readonly="true" style="${gridStyles}">
-      ${paletteState.fullEncoding.map((payload) => html`
+      ${changeEncodingContents.value.map((payload) => html`
         <div class="blissSymbol"><${BlissSymbol} bciAvId=${payload.bciAvId} label=${payload.label} isPresentation="true" /></div>
       `)}
     </div>

--- a/src/GlobalData.ts
+++ b/src/GlobalData.ts
@@ -16,6 +16,7 @@
 import { html } from "htm/preact";
 import { createContext, VNode } from "preact";
 import { useContext, useState } from "preact/hooks";
+import { signal } from "@preact/signals";
 import { EncodingType } from "./index.d";
 
 /**
@@ -79,32 +80,8 @@ export async function initAdaptivePaletteGlobals (mainPaletteContainerId?:string
 }
 
 /**
- * Palette shared states
+ * Signal for updating the contents of the ContentBmwEncoding area.  The value
+ * of the signal is the current array of EncodingType objects to display in the
+ * ContentBmwEncoding area.
  */
-// Create a context to pass the palette states to palette children components
-type PaletteStateType = {
-  fullEncoding: EncodingType[],
-  setFullEncoding: (param: object[]) => void
-};
-
-const defaultPaletteStateContext = {
-  fullEncoding: [],
-  setFullEncoding: () => {}
-};
-const paletteStateContext = createContext<PaletteStateType>(defaultPaletteStateContext);
-
-// Create a provider component that will wrap the components needing access to the global states
-export function paletteStateProvider(props: {children}): VNode {
-  const [fullEncoding, setFullEncoding] = useState([]);
-
-  return html`
-    <${paletteStateContext.Provider} value=${{ fullEncoding, setFullEncoding }}>
-      ${props.children}
-    </${paletteStateContext.Provider}>
-  `;
-}
-
-// Create a custom hook to easily access the global states within components
-export function usePaletteState(): PaletteStateType {
-  return useContext(paletteStateContext);
-}
+export const changeEncodingContents = signal([]);

--- a/src/GlobalData.ts
+++ b/src/GlobalData.ts
@@ -13,11 +13,7 @@
  * Populate and export global data
  */
 
-import { html } from "htm/preact";
-import { createContext, VNode } from "preact";
-import { useContext, useState } from "preact/hooks";
 import { signal } from "@preact/signals";
-import { EncodingType } from "./index.d";
 
 /**
  * The map between cell types (string) and actual components that render corresponding cells

--- a/src/Palette.ts
+++ b/src/Palette.ts
@@ -12,7 +12,7 @@
 import { VNode } from "preact";
 import { html } from "htm/preact";
 import { JsonPaletteType } from "./index.d";
-import { cellTypeRegistry, adaptivePaletteGlobals, paletteStateProvider } from "./GlobalData";
+import { cellTypeRegistry, adaptivePaletteGlobals } from "./GlobalData";
 import "./Palette.scss";
 
 type PalettePropsType = {
@@ -72,13 +72,11 @@ export function Palette (props: PalettePropsType): VNode {
   paletteStore.addPalette(paletteDefinition);
 
   return html`
-  <${paletteStateProvider}>
     <div
       data-palettename="${paletteDefinition.name}"
       class="paletteContainer"
       style="grid-template-columns: repeat(${rowsCols.numColumns}, 1fr);">
         ${theCells}
     </div>
-  </${paletteStateProvider}>
   `;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -22,11 +22,14 @@ import { Palette } from "./Palette";
 import paletteFileMap from "./palettes/palette_file_map.json";
 import firstLayer from "./palettes/palettes.json";
 import goBackCell from "./palettes/backup_palette.json";
+import outputArea from "./palettes/output_area.json";
 
 PaletteStore.paletteFileMap = paletteFileMap;
 adaptivePaletteGlobals.paletteStore.addPalette(firstLayer);
 adaptivePaletteGlobals.paletteStore.addPalette(goBackCell);
+adaptivePaletteGlobals.paletteStore.addPalette(outputArea);
 
 adaptivePaletteGlobals.navigationStack.currentPalette = firstLayer;
+render(html`<${Palette} json=${outputArea} />`, document.getElementById("output_palette"));
 render(html`<${Palette} json=${goBackCell} />`, document.getElementById("backup_palette"));
 render(html`<${Palette} json=${firstLayer}/>`, document.getElementById("mainPaletteDisplayArea"));

--- a/src/palettes/bmw_palette.json
+++ b/src/palettes/bmw_palette.json
@@ -1,39 +1,6 @@
 {
     "name": "BMW Palette",
     "cells": {
-        "bmw-encoding-area": {
-            "type": "ContentBmwEncoding",
-            "options": {
-                "rowStart": 2,
-                "rowSpan": 1,
-                "columnStart": 1,
-                "columnSpan": 12
-            }
-        },
-        "command-del-last-encoding": {
-            "type": "CommandDelLastEncoding",
-            "options": {
-                "label": "Delete",
-                "bciAvId": 12613,
-                "rowStart": 2,
-                "rowSpan": 1,
-                "columnStart": 13,
-                "columnSpan": 1,
-                "ariaControls": "bmw-encoding-area"
-            }
-        },
-        "command-clear-encoding": {
-            "type": "CommandClearEncoding",
-            "options": {
-                "label": "Clear",
-                "bciAvId": 13665,
-                "rowStart": 2,
-                "rowSpan": 1,
-                "columnStart": 14,
-                "columnSpan": 1,
-                "ariaControls": "bmw-encoding-area"
-            }
-        },
         "dem-30a32c78-56fe-4622-9fba-0416b68d72fc": {
             "type": "ActionBmwCodeCell",
             "options": {

--- a/src/palettes/myfamily.json
+++ b/src/palettes/myfamily.json
@@ -1,39 +1,6 @@
 {
   "name": "My Family Palette",
   "cells": {
-    "bmw-encoding-area": {
-        "type": "ContentBmwEncoding",
-        "options": {
-            "rowStart": 2,
-            "rowSpan": 1,
-            "columnStart": 1,
-            "columnSpan": 12
-        }
-    },
-    "command-del-last-encoding": {
-        "type": "CommandDelLastEncoding",
-        "options": {
-            "label": "Delete",
-            "bciAvId": 12613,
-            "rowStart": 2,
-            "rowSpan": 1,
-            "columnStart": 13,
-            "columnSpan": 1,
-            "ariaControls": "bmw-encoding-area"
-        }
-    },
-    "command-clear-encoding": {
-        "type": "CommandClearEncoding",
-        "options": {
-            "label": "Clear",
-            "bciAvId": 13665,
-            "rowStart": 2,
-            "rowSpan": 1,
-            "columnStart": 14,
-            "columnSpan": 1,
-            "ariaControls": "bmw-encoding-area"
-        }
-    },
     "aunt-30a32c78-56fe-4622-9fba-0416b68d72fc": {
       "type": "ActionBmwCodeCell",
         "options": {

--- a/src/palettes/palette_file_map.json
+++ b/src/palettes/palette_file_map.json
@@ -3,5 +3,6 @@
   "My Family Palette": "myfamily",
   "People": "people",
   "BMW Palette": "bmw_palette",
-  "Palettes": "palettes"
+  "Palettes": "palettes",
+  "InputArea": "input_area"
 }

--- a/src/palettes/palettes.json
+++ b/src/palettes/palettes.json
@@ -1,39 +1,6 @@
 {
   "name": "Palettes",
   "cells": {
-  "bmw-encoding-area": {
-    "type": "ContentBmwEncoding",
-    "options": {
-      "rowStart": 2,
-      "rowSpan": 1,
-      "columnStart": 1,
-      "columnSpan": 12
-    }
-  },
-  "command-del-last-encoding": {
-      "type": "CommandDelLastEncoding",
-      "options": {
-        "label": "Delete",
-        "bciAvId": 12613,
-        "rowStart": 2,
-        "rowSpan": 1,
-        "columnStart": 13,
-        "columnSpan": 1,
-        "ariaControls": "bmw-encoding-area"
-      }
-  },
-  "command-clear-encoding": {
-    "type": "CommandClearEncoding",
-    "options": {
-      "label": "Clear",
-      "bciAvId": 13665,
-      "rowStart": 2,
-      "rowSpan": 1,
-      "columnStart": 14,
-      "columnSpan": 1,
-      "ariaControls": "bmw-encoding-area"
-    }
-  },
   "myfamily-30a32c78-56fe-4622-9fba-0416b68d72fc": {
    "type": "ActionBranchToPaletteCell",
    "options": {

--- a/src/palettes/people.json
+++ b/src/palettes/people.json
@@ -1,39 +1,6 @@
 {
   "name": "People",
   "cells": {
-    "bmw-encoding-area": {
-        "type": "ContentBmwEncoding",
-        "options": {
-            "rowStart": 2,
-            "rowSpan": 1,
-            "columnStart": 1,
-            "columnSpan": 12
-        }
-    },
-    "command-del-last-encoding": {
-        "type": "CommandDelLastEncoding",
-        "options": {
-            "label": "Delete",
-            "bciAvId": 12613,
-            "rowStart": 2,
-            "rowSpan": 1,
-            "columnStart": 13,
-            "columnSpan": 1,
-            "ariaControls": "bmw-encoding-area"
-        }
-    },
-    "command-clear-encoding": {
-        "type": "CommandClearEncoding",
-        "options": {
-            "label": "Clear",
-            "bciAvId": 13665,
-            "rowStart": 2,
-            "rowSpan": 1,
-            "columnStart": 14,
-            "columnSpan": 1,
-            "ariaControls": "bmw-encoding-area"
-        }
-    },
     "couple-30a32c78-56fe-4622-9fba-0416b68d72fc": {
       "type": "ActionBmwCodeCell",
         "options": {


### PR DESCRIPTION
Code changes for separating the output display area of symbols from other palettes.  In brief:

- Move the JSON description of the `ContentsBmwEncoding` component to its own `.json` file,
- Remove the repetition of the same description from each of the other palette `.json` files,
- Create a `<div>` for rendering the `ContentsBmwEncoding` component on the page,
- Respond to symbol selections on various palettes by updating the contents of the `ContentsBmwEncoding` component,
- Respond to the "Clear" and "Delete" symbols.

Addresses issue #10