### PR TITLE
fix: improve text label for the prompt text entry area

### DIFF
--- a/demos/Ollama Chat Service/ollama.html
+++ b/demos/Ollama Chat Service/ollama.html
@@ -12,7 +12,7 @@
     <select id="modelSelect"></select>
   </p>
   <p>
-    <label for="prompt">Prompt:</label><br>
+    <label for="prompt">What does this express: ?</label><br>
     <textarea type="text" id="prompt" rows="4" cols="50"></textarea><br>
   </p>
   <p>

--- a/demos/Ollama Chat Service/whatExpress.html
+++ b/demos/Ollama Chat Service/whatExpress.html
@@ -175,7 +175,7 @@
   <select id="modelSelect" onchange="setSelectedModel()"></select>
 </p>
 <p>
-  <label for="prompt">Prompt:</label><br>
+  <label for="prompt">What does this express: ?</label><br>
   <textarea type="text" id="prompt" rows="4" cols="50" oninput="setAskButtonsEnabledState()"></textarea><br>
   <button onclick="askClicked()" id="justAsk" disabled>Ask</button>
   <button onclick="askClicked(this)" id="single" disabled>Answer with a single grammatically correct sentence</button>


### PR DESCRIPTION
This is a simple PR to adjust the label on the text area for creating the input to send to the LLM.  Instead of the uninformative "Prompt:" , it is now "What does this express: ?"
