### PR TITLE
Feat: Integrate Ollama and query all of its models.

### DIFF
--- a/apps/ollama/README.md
+++ b/apps/ollama/README.md
@@ -1,0 +1,130 @@
+# Ollama Chat Web-App
+
+The following instructions describe how to set up a local Ollama
+service with which Ollama chat web-app can send queries, and show the ollama
+service's responses.
+
+## Ollama Service Set Up
+
+First, set up the Ollama service. Follow the directions found in the [Ollama
+Github project](https://github.com/ollama/ollama?tab=readme-ov-file).  Either
+download and install the version of Ollama for your OS, or use the
+[Docker](https://github.com/ollama/ollama?tab=readme-ov-file#docker) approach.
+
+Secondly, follow the instructions given in Ollama's [Model Library](https://github.com/ollama/ollama?tab=readme-ov-file#model-library)
+to install and run a language model.
+
+Finally launch the ollama service.  For example, if the command-line version of
+Ollama was downloaded, then for macOS, in a terminal execute `ollama serve`.
+See the Ollama documentation for more information.
+
+Once the Ollama Service is installed, launched and running, proceed to the next
+steps.
+
+## Chat Web-App
+
+There are two versions of the web-app.  They appear identical within the browser
+window, differing in the details of how they interact with the Ollama service.
+The differences between the two, and the instructions for running each is given
+in the next sections.
+
+### Chat using `fetch()`
+
+The `whatExpress.html` web-app uses the browser's built-in `fetch()` function to
+send queries to the Ollama service.  The advantage is that no other support
+library or code needs to be installed.  The disadvantages are that setting up
+the parameters for `fetch()` and managing the response are a little more
+involved.  In terms of the request, it is necessary to provide the request
+headers, specify that it is a `POST` request, make the request of the correct
+Ollama service endpoint, set the `Content-Type`, and properly set up the body
+payload. For the chat end-point, the response is a special type of JSON, namely
+`json-nd` that must be parsed and processed to retrieve the actual AI's text to
+show on the web page. The second web-app, discussed in the next section, uses a
+library that hides a lot of these details when interacting with the Ollama
+service.
+
+The demo web-app is launched in the same way as the main Adaptive Palette
+application:
+
+```text
+npm run dev
+```
+
+See the [Start a Development Server](../../README.md#start-a-development-server)
+section in the main README document for more details.
+
+Once the development server is running, open this `localhost` url from within a
+browser:
+[`http://localhost:3000/apps/ollama/ollama.html`](http://localhost:3000/apps/ollama/ollama.html)
+
+### Chat using Ollama Client Library
+
+The `ollama.html` web-app uses the [Ollama browser API](https://github.com/ollama/ollama-js/?tab=readme-ov-file#browser-usage)
+for communication with the Ollama service, using the library's `chat()`
+function.  The response from `chat()` in this case is an array of JSON
+structures each containing a part of the textual response from the LLM.  These
+are concatenated together and then displayed on the web page.
+
+In the adaptive palette main directory, execute this command line instruction to
+install the ollama JavaScript package:
+
+```text
+npm install ollama
+```
+
+Launch the web-app chat client using the command:
+
+```text
+npm run dev
+```
+
+See the [Start a Development Server](../../README.md#start-a-development-server)
+section in the main README document for more details.
+
+Once the development server is running, open this `localhost` url from within a
+browser:
+[`http://localhost:3000/demos/Ollama%20Chat%20Service/ollama.html`](http://localhost:3000/demos/Ollama%20Chat%20Service/ollama.html)
+
+## How to Chat
+
+The following describes how to use the web-app regardless of which one is
+tested.
+
+Near the top is a pull-down menu for selecting the language model to use for the
+chat. If no action is taken, the language model shown will be the one that is
+used. If no language models are shown in the pull-down, follow
+Ollama's [Model Library](https://github.com/ollama/ollama?tab=readme-ov-file#model-library)
+instructions to install language models.
+
+There are two ways to chat with Ollama.  All text added to the text field of the
+chat web-app client is prefixed with the question "What does this express:"
+That is, if the text box contains:
+
+```text
+Horse brown eat quickly oats dried
+```
+
+then the full prompt sent to the LLM is:
+
+```text
+What does this express: "Horse brown eat quickly oats dried"?
+```
+
+Pressing the "Ask" button will send the query exactly as shown above.  The reply
+will likely be somewhat wordy.  Ollama will offer an analysis of the chat query,
+how the query might be improved, and it will end with a response.
+
+If the "Answer with a single grammatically correct sentence" button is pressed,
+then the query sent to the LLM service is modified in an attempt to have the LLM
+return a single sentence, like so:
+
+```text
+What does this express: "Horse brown eat quickly oats dried"?  Answer
+with a single grammatically correct sentence.
+```
+
+Ollama will likely respond with a single sentence for this query.
+
+The checkbox labelled "Show results for all models", if checked, will cause the
+app to query all available models, and show the results of each within its own
+section on the web app's page.

--- a/apps/ollama/README.md
+++ b/apps/ollama/README.md
@@ -1,8 +1,8 @@
 # Ollama Chat Web-App
 
-The following instructions describe how to set up a local Ollama
-service with which Ollama chat web-app can send queries, and show the ollama
-service's responses.
+The following instructions describe how to set up a local Ollama service such
+that the locally hosted Ollama chat web-app can send queries, and show the
+ollama service's responses.
 
 ## Ollama Service Set Up
 
@@ -22,42 +22,6 @@ Once the Ollama Service is installed, launched and running, proceed to the next
 steps.
 
 ## Chat Web-App
-
-There are two versions of the web-app.  They appear identical within the browser
-window, differing in the details of how they interact with the Ollama service.
-The differences between the two, and the instructions for running each is given
-in the next sections.
-
-### Chat using `fetch()`
-
-The `whatExpress.html` web-app uses the browser's built-in `fetch()` function to
-send queries to the Ollama service.  The advantage is that no other support
-library or code needs to be installed.  The disadvantages are that setting up
-the parameters for `fetch()` and managing the response are a little more
-involved.  In terms of the request, it is necessary to provide the request
-headers, specify that it is a `POST` request, make the request of the correct
-Ollama service endpoint, set the `Content-Type`, and properly set up the body
-payload. For the chat end-point, the response is a special type of JSON, namely
-`json-nd` that must be parsed and processed to retrieve the actual AI's text to
-show on the web page. The second web-app, discussed in the next section, uses a
-library that hides a lot of these details when interacting with the Ollama
-service.
-
-The demo web-app is launched in the same way as the main Adaptive Palette
-application:
-
-```text
-npm run dev
-```
-
-See the [Start a Development Server](../../README.md#start-a-development-server)
-section in the main README document for more details.
-
-Once the development server is running, open this `localhost` url from within a
-browser:
-[`http://localhost:3000/apps/ollama/ollama.html`](http://localhost:3000/apps/ollama/ollama.html)
-
-### Chat using Ollama Client Library
 
 The `ollama.html` web-app uses the [Ollama browser API](https://github.com/ollama/ollama-js/?tab=readme-ov-file#browser-usage)
 for communication with the Ollama service, using the library's `chat()`
@@ -83,21 +47,31 @@ section in the main README document for more details.
 
 Once the development server is running, open this `localhost` url from within a
 browser:
-[`http://localhost:3000/demos/Ollama%20Chat%20Service/ollama.html`](http://localhost:3000/demos/Ollama%20Chat%20Service/ollama.html)
+[`http://localhost:3000/apps/ollama/ollama.html`](http://localhost:3000/apps/ollama/ollama.html)
 
 ## How to Chat
 
 The following describes how to use the web-app regardless of which one is
 tested.
 
-Near the top is a pull-down menu for selecting the language model to use for the
-chat. If no action is taken, the language model shown will be the one that is
-used. If no language models are shown in the pull-down, follow
-Ollama's [Model Library](https://github.com/ollama/ollama?tab=readme-ov-file#model-library)
+There is a pull-down menu near the top of the "LLM Settings" that selects the
+language model to use for the chat. If no action is taken, the language model
+shown will be the one that is used. If no language models are shown in the
+pull-down, follow Ollama's [Model Library](https://github.com/ollama/ollama?tab=readme-ov-file#model-library)
 instructions to install language models.
 
-There are two ways to chat with Ollama.  All text added to the text field of the
-chat web-app client is prefixed with the question "What does this express:"
+Alternatively, check the checkbox labelled "Show results for all models".  Any
+prompts sent to the chatbot will send the same prompt to multiple LLMs so their
+responses can be compared.
+
+Enter a system prompt in the text area just below the checkbox.  This prompt
+will be supplied to the language model(s) as a overall system prompt describing
+the nature of the chat.  This prompt is optional, and the text area can be left
+blank.
+
+Individual prompts are entered into the text area labelled "What does this
+express: ?".  There are two ways to chat with an LLM.  All text added to the
+text area is prefixed with the question "What does this express:"
 That is, if the text box contains:
 
 ```text
@@ -111,11 +85,11 @@ What does this express: "Horse brown eat quickly oats dried"?
 ```
 
 Pressing the "Ask" button will send the query exactly as shown above.  The reply
-will likely be somewhat wordy.  Ollama will offer an analysis of the chat query,
-how the query might be improved, and it will end with a response.
+will likely be somewhat wordy.  The language model will offer an analysis of the
+chat query, how the query might be improved, and it will end with a response.
 
 If the "Answer with a single grammatically correct sentence" button is pressed,
-then the query sent to the LLM service is modified in an attempt to have the LLM
+then the query sent to the LLM is modified in an attempt to have the LLM
 return a single sentence, like so:
 
 ```text
@@ -124,7 +98,3 @@ with a single grammatically correct sentence.
 ```
 
 Ollama will likely respond with a single sentence for this query.
-
-The checkbox labelled "Show results for all models", if checked, will cause the
-app to query all available models, and show the results of each within its own
-section on the web app's page.

--- a/apps/ollama/ollama.html
+++ b/apps/ollama/ollama.html
@@ -7,17 +7,20 @@
     import "./ollama.js";
   </script>
   <h1>Using Ollama with LLMs Running Locally</h1>
-  <fieldset>
-    <legend>LLMs</legend>
-    <p>
-      <input type="checkbox" id="allModels">
-      <label for="allModels">Show results for all models</label>, or
-    </p>
-    <p>
-      <label for="modelSelect">Choose a model:</label>
-      <select id="modelSelect"></select>
-    </p>
-  </fieldset>
+  <div style="width:33%">
+    <fieldset>
+      <legend>LLMs</legend>
+      <p>
+        <input type="checkbox" id="allModels">
+        <label for="allModels">Show results for all models</label>, or
+      </p>
+      <p>
+        <label for="modelSelect">Choose a model:</label>
+        <select id="modelSelect"></select>
+      </p>
+      <p><button id="flushModelSections">Delete Models' Output</button>
+    </fieldset>
+  </div>
   <p>
     <label for="prompt">What does this express: ?</label><br>
     <textarea type="text" id="prompt" rows="4" cols="50"></textarea><br>

--- a/apps/ollama/ollama.html
+++ b/apps/ollama/ollama.html
@@ -1,0 +1,33 @@
+<html>
+<head>
+  <title>Experimenting with Ollama in a Browser (Ollama Client Library version)</title>
+</head>
+<body>
+  <script type="module">
+    import "./ollama.js";
+  </script>
+  <h1>Experimenting with Ollama in a Browser (Ollama Client Library version)</h1>
+  <fieldset>
+    <legend>LLMs</legend>
+    <p>
+      <input type="checkbox" id="allModels">
+      <label for="allModels">Show results for all models</label>, or
+    </p>
+    <p>
+      <label for="modelSelect">Choose a model:</label>
+      <select id="modelSelect"></select>
+    </p>
+  </fieldset>
+  <p>
+    <label for="prompt">What does this express: ?</label><br>
+    <textarea type="text" id="prompt" rows="4" cols="50"></textarea><br>
+  </p>
+  <p>
+    <button id="justAsk" disabled>Ask</button>
+    <button id="singleSentence" disabled>Answer with a single grammatically correct sentence</button>
+  </p>
+  <p id="ollamaOutput">
+  THIS PARAGRPAPH INTENTIONALLY LEFT BLANK
+  </p>
+</body>
+</html>

--- a/apps/ollama/ollama.html
+++ b/apps/ollama/ollama.html
@@ -7,29 +7,33 @@
     import "./ollama.js";
   </script>
   <h1>Using Ollama with LLMs Running Locally</h1>
-  <div style="width:33%">
+  <div style="width:50%">
     <fieldset>
-      <legend>LLMs</legend>
+      <legend>LLM Settings</legend>
       <p>
         <label for="modelSelect">Choose a model:</label>
         <select id="modelSelect"></select>
       </p>
       <p>or</p>
       <p>
-        <input type="checkbox" id="allModels">
+        <input type="checkbox" id="allModels" aria-controls="modelSelect">
         <label for="allModels">Show results for all models</label>
       </p>
-      <p><button id="flushModelSections">Clear Output</button>
+      <p>
+        <label for="systemPrompt">System prompt (optional, can be empty):</label><br>
+        <textarea type="text" id="systemPrompt" rows="10" cols="50"></textarea>
+      </p>
     </fieldset>
   </div>
   <p>
     <label for="prompt">What does this express: ?</label><br>
-    <textarea type="text" id="prompt" rows="4" cols="50"></textarea><br>
+    <textarea type="text" id="prompt" rows="10" cols="70"></textarea>
   </p>
   <p>
     <button id="justAsk" disabled>Ask</button>
     <button id="singleSentence" disabled>Answer with a single grammatically correct sentence</button>
   </p>
+  <p><button id="flushModelSections" style="text-aling">Clear Output</button></p>
   <p id="ollamaOutput">
   THIS PARAGRPAPH INTENTIONALLY LEFT BLANK
   </p>

--- a/apps/ollama/ollama.html
+++ b/apps/ollama/ollama.html
@@ -11,14 +11,15 @@
     <fieldset>
       <legend>LLMs</legend>
       <p>
-        <input type="checkbox" id="allModels">
-        <label for="allModels">Show results for all models</label>, or
-      </p>
-      <p>
         <label for="modelSelect">Choose a model:</label>
         <select id="modelSelect"></select>
       </p>
-      <p><button id="flushModelSections">Delete Models' Output</button>
+      <p>or</p>
+      <p>
+        <input type="checkbox" id="allModels">
+        <label for="allModels">Show results for all models</label>
+      </p>
+      <p><button id="flushModelSections">Clear Output</button>
     </fieldset>
   </div>
   <p>

--- a/apps/ollama/ollama.html
+++ b/apps/ollama/ollama.html
@@ -1,12 +1,12 @@
 <html>
 <head>
-  <title>Experimenting with Ollama in a Browser (Ollama Client Library version)</title>
+  <title>Using Ollama with LLMs Running Locally</title>
 </head>
 <body>
   <script type="module">
     import "./ollama.js";
   </script>
-  <h1>Experimenting with Ollama in a Browser (Ollama Client Library version)</h1>
+  <h1>Using Ollama with LLMs Running Locally</h1>
   <fieldset>
     <legend>LLMs</legend>
     <p>

--- a/apps/ollama/ollama.js
+++ b/apps/ollama/ollama.js
@@ -138,11 +138,22 @@ function askClicked(event) {
  * @return {Object}           - The response from the service.
  */
 async function queryChat (query, modelName) {
-  const message = { role: "user", content: query };
+  let messageArray = [];
+  const textFromSystemPrompt = document.getElementById("systemPrompt").value.trim();
+  if (textFromSystemPrompt !== "") {
+    messageArray.push({
+      role: "system",
+      content: textFromSystemPrompt
+    });
+    console.debug(`queryChat(): system prompt is: "${textFromSystemPrompt}")`);
+  }
+  messageArray.push({ role: "user", content: query });
   const response = await ollama.chat({
     model: modelName,
-    messages: [message],
-    stream: true
+    messages: messageArray,
+    raw: true,
+    stream: true,
+    keep_alive: 15
   });
   return response;
 }
@@ -255,6 +266,7 @@ function createOutputSection(modelName) {
     paragraph.setAttribute("id", `${modelName}_output`);
     paragraph.append("Working ...");
     sectionEl.appendChild(paragraph);
+    paragraph.scrollIntoView(false);
   }
   else {
     // Rationale: if <esction id=secton_modelName ...> exists, it was created

--- a/apps/ollama/ollama.js
+++ b/apps/ollama/ollama.js
@@ -265,6 +265,17 @@ function createOutputSection(modelName) {
   return paragraph;
 }
 
+/**
+ * Flush all of the model sections contents -- remove the sections.
+ */
+async function flushModelOutputSections () {
+  const names = await getModelNames();
+  names.forEach((modelName) => {
+    document.getElementById(`section_${modelName}`)?.remove();
+  });
+  document.getElementById("ollamaOutput").innerText = "";
+}
+
 const justAskButton = document.getElementById("justAsk");
 const singleSentenceButton = document.getElementById("singleSentence");
 const promptTextArea = document.getElementById("prompt");
@@ -273,6 +284,7 @@ justAskButton.addEventListener("click", askClicked);
 singleSentenceButton.addEventListener("click", askClicked);
 document.getElementById("modelSelect").addEventListener("change", setSelectedModel);
 document.getElementById("allModels").addEventListener("click", useAllModels);
+document.getElementById("flushModelSections").addEventListener("click", flushModelOutputSections);
 promptTextArea.addEventListener("input", setAskButtonsEnabledState);
 
 // Set up the model <select> element

--- a/apps/ollama/ollama.js
+++ b/apps/ollama/ollama.js
@@ -38,7 +38,7 @@ async function getModelNames () {
  * Initialize the model <select> element's options:
  * - set the <select>'s options,
  * - enable/disable the <select> based on the use-all-models checkbox,
- * - set the `nmeeOfModelToUse` variable to one of:
+ * - set the `nameOfModelToUse` variable to one of:
  *   - a single model name,
  *   - `USE_ALL_MODELS`,
  *   - `NO_AVAILABLE_MODELS`
@@ -269,7 +269,7 @@ function createOutputSection(modelName) {
     paragraph.scrollIntoView(false);
   }
   else {
-    // Rationale: if <esction id=secton_modelName ...> exists, it was created
+    // Rationale: if <section id=section_modelName ...> exists, it was created
     // the last time and, hence, so was its inner <p id=modelNmae_output ...>
     paragraph = document.getElementById(`${modelName}_output`);
   }

--- a/apps/ollama/ollama.js
+++ b/apps/ollama/ollama.js
@@ -15,7 +15,6 @@ import ollama from "ollama/browser";
 let nameOfModelToUse = "";
 const USE_ALL_MODELS = "useAllModels";
 const NO_AVAILABLE_MODELS = "No Available Models";
-const OUTPUT_DIV_TEMPLATE = "<div>"
 
 /**
  * Retrieve a list of LLMs available from the service
@@ -226,11 +225,11 @@ function setAskButtonsEnabledState() {
 async function queryEachModel (promptText) {
   const names = await getModelNames();
   names.forEach ((modelName) => {
-     queryChat(promptText, modelName)
-     .then((response) => {
-       const outputEl = createOutputSection(modelName);
-       outputResult(response, outputEl, "No Result");
-     });
+    queryChat(promptText, modelName)
+      .then((response) => {
+        const outputEl = createOutputSection(modelName);
+        outputResult(response, outputEl, "No Result");
+      });
   });
 }
 

--- a/apps/ollama/ollama.js
+++ b/apps/ollama/ollama.js
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2024 Inclusive Design Research Centre, OCAD University
+ * All rights reserved.
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ *
+ * You may obtain a copy of the License at
+ * https://github.com/inclusive-design/adaptive-palette/blob/main/LICENSE
+ */
+
+import ollama from "ollama/browser";
+
+// Default name of model used (aka, none).  Set in setSelectedModel() handler.
+let nameOfModelToUse = "";
+const USE_ALL_MODELS = "useAllModels";
+
+// Function to retrieve a list of LLM's available from the service
+async function getModelNames () {
+  let modelNames = [];
+  try {
+    const list = await ollama.list();
+    list.models.forEach( (model) => {
+      modelNames.push(model.name);
+    });
+  }
+  catch (error) {
+    console.debug(error);
+  }
+  return modelNames;
+}
+
+// Initialize the model <select> element's options.
+async function initModelSelect () {
+  const selectElement = document.getElementById("modelSelect");
+  const modelNames = await getModelNames();
+
+  if (modelNames.length === 0) {
+    selectElement.add(new Option("No Available Models"));
+  }
+  else {
+    modelNames.forEach( (aName) => {
+      selectElement.add(new Option(aName));
+    });
+  }
+  // Set the enabled/disabled state of the <select> based on whether the "use
+  // all models" checkbox is checked.  Then set `nameOfModelToUse` either to
+  // the <select>'s first item, or to the special USE_ALL_MODELS.
+  if (enableDisableModelSelect()) {
+    nameOfModelToUse = USE_ALL_MODELS;
+  }
+  else {
+    nameOfModelToUse = selectElement.item(0).label;
+  }
+  // Make sure the enabled state of the "Ask" buttons is correct.  This is
+  // mostly for a refresh of the page.
+  setAskButtonsEnabledState();
+}
+
+// Set the enabled state of the model <select> based on the checked state of
+// the "all models" checkbox.
+function enableDisableModelSelect () {
+  const selectElement = document.getElementById("modelSelect");
+  const allModelsCheckbox = document.getElementById("allModels");
+  if (allModelsCheckbox.checked) {
+    selectElement.setAttribute("disabled", "disabled");
+  }
+  else {
+    selectElement.removeAttribute("disabled");
+  }
+  // Return the checked state of the checkbox and the select element itself
+  return { useAllModels: allModelsCheckbox.checked, selectEl: selectElement };
+}
+
+// Handle model select element when a new selection is made.
+function setSelectedModel () {
+  const selectElement = document.getElementById("modelSelect");
+  nameOfModelToUse = selectElement.selectedOptions[0].label;
+}
+
+// Handle the "use all models" checkbox
+function useAllModels () {
+  const allModelsChecked = enableDisableModelSelect();
+  if (allModelsChecked.useAllModels) {
+    nameOfModelToUse = USE_ALL_MODELS;
+  }
+  else {
+    nameOfModelToUse = allModelsChecked.selectEl.selectedOptions[0].label;
+  }
+}
+
+// Handle click on "Ask" buttons
+function askClicked(event) {
+  const singleSentence = "Answer with a single grammatically correct sentence.";
+  // Empty out the response area
+  document.getElementById("ollamaOutput").innerText = "Working...";
+  if (event.target.id === "singleSentence") {
+    executeAsk(singleSentence);
+  }
+  else {
+    executeAsk();
+  }
+}
+
+// Function for passing the chat prompt using ollama service.
+async function queryChat (query) {
+  const message = { role: "user", content: query };
+  const response = await ollama.chat({
+    model: nameOfModelToUse,
+    messages: [message],
+    stream: true
+  });
+  return response;
+}
+
+// Handle the "Ask" button press
+async function executeAsk (addSingleToPrompt) {
+  let promptText = document.getElementById("prompt").value;
+  if (addSingleToPrompt) {
+    promptText += addSingleToPrompt;
+  }
+  console.debug(`executeAsk(): prompt is "${promptText}"`);
+  const response = await queryChat(promptText);
+  outputResult(response, document.getElementById("ollamaOutput"), "No Result");
+}
+
+// Process the response from the ollama service and put it on the web page
+async function outputResult(response, outputEl) {
+  let LlmOutput = "";
+  for await (const aPart of response) {
+    console.debug(aPart.message.content);
+    LlmOutput += aPart.message.content;
+  }
+  outputEl.innerText = LlmOutput;
+}
+
+// Check if the input <textarea> is empty.
+function isTextInputEmpty() {
+  return promptTextArea.value.trim() === "";
+}
+
+// Enable/diable "Ask" buttons depending on whether the prompt input has
+// any text in it or if there is an LLM to query.
+function setAskButtonsEnabledState() {
+  if (isTextInputEmpty() || nameOfModelToUse === "No Available Models") {
+    justAskButton.setAttribute("disabled", "disabled");
+    singleSentenceButton.setAttribute("disabled", "disabled");
+  }
+  else {
+    justAskButton.removeAttribute("disabled");
+    singleSentenceButton.removeAttribute("disabled");
+  }
+}
+
+const justAskButton = document.getElementById("justAsk");
+const singleSentenceButton = document.getElementById("singleSentence");
+const promptTextArea = document.getElementById("prompt");
+
+justAskButton.addEventListener("click", askClicked);
+singleSentenceButton.addEventListener("click", askClicked);
+document.getElementById("modelSelect").addEventListener("change", setSelectedModel);
+document.getElementById("allModels").addEventListener("click", useAllModels);
+promptTextArea.addEventListener("input", setAskButtonsEnabledState);
+
+// Set up the model <select> element
+initModelSelect();
+


### PR DESCRIPTION
This is based on a similar Ollama demonstrations in the `demos/Ollama Chat Service` folder, modified to allow a user to query all of the models currently available within the Ollama service with the same prompt.  This allows one to compare the results of different LLMs.

Note that this is somewhat more mature than just a demo, so I created a new folder called "apps" for it (and other potential apps).  It is based on the [demo](https://github.com/inclusive-design/adaptive-palette/blob/main/demos/Ollama%20Chat%20Service/ollama.html) that used the Ollama JavaScript library for interacting with the Ollama service.
