### PR TITLE
feat: web app for previewing svg markup returned by `BlissSVGBuilder`

### DIFF
--- a/apps/svg-preview/svg-preview.html
+++ b/apps/svg-preview/svg-preview.html
@@ -1,0 +1,31 @@
+<html>
+<head>
+  <title>Bliss SVG Previewer</title>
+  <style>
+    svg {
+      border: 2px solid gray;
+      background: GhostWhite;
+    }
+  </style>
+</head>
+<body>
+  <script type="module">
+    import "./svg-preview.ts";
+  </script>
+  <h1>Bliss SVG Previewer</h1>
+  <p>
+    The encoding string entered below is a space separated sequence of BCI-AV
+    identfiers and separators such as "/" and ";".  The sequence can be as
+    simple as a single BCI-AV identifier.
+  <p>
+    <label for="bciAvIdType">Encoding:</label><br>
+    <input type="text" id="bciAvIdType" size="40">
+  </p>
+  <p>
+    <button id="preview">Preview</button>
+  </p>
+  <p>
+  <p>Symbol will be displayed below:</p>
+  <p id="display"></p>
+</body>
+</html>

--- a/apps/svg-preview/svg-preview.ts
+++ b/apps/svg-preview/svg-preview.ts
@@ -35,28 +35,37 @@ function getAndDisplayBliss () {
     displayElement.innerText = "Please input an encoding";
   }
   else {
-    // Remove any commas, double or single quotes, then split into an array.
-    const encodingArray = inputString.replace(/[,"']/g,"").split(" ");
-    // Loop to convert all the number strings into integers, e.g., "5" => 5.
-    // Regarding `isNan()`: it returns false for anything number-like and true
-    // for any punctuation.  For example, the string "5" and the number 5 are
-    // not NaN, but "/" is NaN.
+    const encodingArray = inputString
+      .replace(/["']/g,"")    // remove all quotation marks
+      .replace(/\s\s+/g, " ") // reduce all whitespace to a single space
+      .split(" ");            // create an array of strings
+    // Loop to remove any trailing commas from a string in the array, and to
+    // convert all the number strings into integers, e.g., "5" => 5.
+    // Regarding `parseInt()/isNaN()`: any item that is a number or number-like
+    // is not `NaN`, but punctuation is.  For example, the string "5" and the
+    // number 5 both parse to a numeric value, but "/" is parsed to `NaN`.
     encodingArray.forEach( (item, index, array) => {
-      if (!isNaN(item)) {
-        array[index] = parseInt(item);
+      item = item.replace(/,+$/, "");   // remove any trailing commas
+      const value = parseInt(item);
+      if (isNaN(value)) {
+        array[index] = item;
+      }
+      else {
+        array[index] = value;
       }
     });
     console.debug(encodingArray);
     blissSvgEl = getSvgElement(encodingArray) || undefinedSpanEl;
-  }
-  // If the `displayElement` has a child from a previous run, replace it with
-  // the latest result.
-  const childToReplace = displayElement.children[0];
-  if (childToReplace) {
-    displayElement.replaceChild(blissSvgEl, childToReplace);
-  }
-  else {
-    displayElement.appendChild(blissSvgEl);
+
+    // If the `displayElement` has a child from a previous run, replace it with
+    // the latest result, otherwise add a new child.
+    const childToReplace = displayElement.children[0];
+    if (childToReplace) {
+      displayElement.replaceChild(blissSvgEl, childToReplace);
+    }
+    else {
+      displayElement.appendChild(blissSvgEl);
+    }
   }
 }
 

--- a/apps/svg-preview/svg-preview.ts
+++ b/apps/svg-preview/svg-preview.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024 Inclusive Design Research Centre, OCAD University
+ * All rights reserved.
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ *
+ * You may obtain a copy of the License at
+ * https://github.com/inclusive-design/adaptive-palette/blob/main/LICENSE
+ */
+
+import { initAdaptivePaletteGlobals } from "../../src/client/GlobalData";
+import { getSvgElement } from "../../src/client/SvgUtils";
+
+// Initialize any globals used elsewhere in the code.
+await initAdaptivePaletteGlobals("mainPaletteDisplayArea");
+
+const encodingInputElement = document.getElementById("bciAvIdType");
+const displayElement = document.getElementById("display");
+const undefinedSpanEl = document.createElement("span");
+undefinedSpanEl.innerText = "One or more BCI-AV-IDs are not valid";
+
+/**
+ * Given the encoding string for a Bliss character or word, get the SVG markup
+ * for it, and then add it to the preview area.  Note that the encoding string
+ * is either a single BCi-AV identifier or a space separated sequence of BCi-AV
+ * identifier and "/" or ";"
+ */
+function getAndDisplayBliss () {
+  const inputString = encodingInputElement.value;
+  let blissSvgEl;
+
+  displayElement.innerText = "";    // clear the display area
+  if (inputString.trim() === "") {
+    displayElement.innerText = "Please input an encoding";
+  }
+  else {
+    // Remove any commas, double or single quotes, then split into an array.
+    const encodingArray = inputString.replace(/[,"']/g,"").split(" ");
+    // Loop to convert all the number strings into integers, e.g., "5" => 5.
+    // Regarding `isNan()`: it returns false for anything number-like and true
+    // for any punctuation.  For example, the string "5" and the number 5 are
+    // not NaN, but "/" is NaN.
+    encodingArray.forEach( (item, index, array) => {
+      if (!isNaN(item)) {
+        array[index] = parseInt(item);
+      }
+    });
+    console.debug(encodingArray);
+    blissSvgEl = getSvgElement(encodingArray) || undefinedSpanEl;
+  }
+  // If the `displayElement` has a child from a previous run, replace it with
+  // the latest result.
+  const childToReplace = displayElement.children[0];
+  if (childToReplace) {
+    displayElement.replaceChild(blissSvgEl, childToReplace);
+  }
+  else {
+    displayElement.appendChild(blissSvgEl);
+  }
+}
+
+document.getElementById("preview").addEventListener("click", getAndDisplayBliss);


### PR DESCRIPTION
This adds another web application to the `./apps` folder, specifically `./apps/svg-preview`.

The app can be run on localhost and is started by the existing `npm run serveAppsDemos` script.  If so launched, use this following URL to access it:  `http://localhost:5173/apps/svg-preview/svg-preview.html`
