### PR TITLE
feat: update version of svg-builder to latest alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@types/node": "^22.5.1",
         "@types/serve-static": "^1.15.7",
         "@xenova/transformers": "^2.17.2",
-        "bliss-svg-builder": "^0.1.0-alpha.4",
+        "bliss-svg-builder": "^0.1.0-alpha.6",
         "express": "^4.19.2",
         "faiss-node": "^0.5.1",
         "htm": "^3.1.1",
@@ -5275,9 +5275,9 @@
       }
     },
     "node_modules/bliss-svg-builder": {
-      "version": "0.1.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/bliss-svg-builder/-/bliss-svg-builder-0.1.0-alpha.4.tgz",
-      "integrity": "sha512-wOk69Xb6xjrliEWasJmk8mfA4d3CtorNffO1b4zLVIYvtZ9dPtwV9ehrJloatXIjyxpFHuJTfqElkqW41udEsA=="
+      "version": "0.1.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/bliss-svg-builder/-/bliss-svg-builder-0.1.0-alpha.6.tgz",
+      "integrity": "sha512-M6yQbWCE9LbKW1+sJeo6PP4AY9ZL1zFKEcF122fCwXCSEfDF6uUuH9FvGFRgR6jD0nq7BT3bl0Cqc2C5sBVGwQ=="
     },
     "node_modules/body-parser": {
       "version": "1.20.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/node": "^22.5.1",
     "@types/serve-static": "^1.15.7",
     "@xenova/transformers": "^2.17.2",
-    "bliss-svg-builder": "^0.1.0-alpha.4",
+    "bliss-svg-builder": "^0.1.0-alpha.6",
     "express": "^4.19.2",
     "faiss-node": "^0.5.1",
     "htm": "^3.1.1",


### PR DESCRIPTION
The latest version of the [bliss-svg-builder](https://github.com/hlridge/bliss-svg-builder) has fixes for drawing indicators correctly.  This PR is for updating the adaptive-palette project's `package.json` to reflect this.
