### PR TITLE
fix: adjust test configurations

### DIFF
--- a/jest.config.client.cjs
+++ b/jest.config.client.cjs
@@ -20,4 +20,5 @@ module.exports = {
   moduleNameMapper: {
     "^.+\\.(css|less|scss)$": "babel-jest"
   },
+  cacheDirectory: "/tmp"
 };

--- a/jest.config.node.cjs
+++ b/jest.config.node.cjs
@@ -18,5 +18,6 @@ module.exports = {
   moduleFileExtensions: ["mjs", "js", "jsx", "ts", "tsx", "json", "node"],
   moduleNameMapper: {
     "^.+\\.(css|less|scss)$": "babel-jest"
-  }
+  },
+  cacheDirectory: "/tmp"
 };

--- a/src/server/vectorStoreHandler/index.test.ts
+++ b/src/server/vectorStoreHandler/index.test.ts
@@ -52,7 +52,7 @@ describe("Test vectorStoreHandler", () => {
       const results = await vectorStoreHandler.similaritySearch(vectorStore, "roy");
       expect(results.length).toBe(4);
       verifyResults(results);
-    }, 10000);
+    }, 13000);
 
     it("should perform the search with a vector store by returning requested number of top matches", async () => {
       const topK = 3;
@@ -60,6 +60,6 @@ describe("Test vectorStoreHandler", () => {
       const results = await vectorStoreHandler.similaritySearch(vectorStore, "roy", topK);
       expect(results.length).toBe(topK);
       verifyResults(results);
-    }, 10000);
+    }, 13000);
   });
 });


### PR DESCRIPTION
1. Add a `cacheDirectory` to the two jest configuration files to use publicly available "/tmp" directory and avoid the `EACCES` error,
2. Increase the time-out for the server tests to 13sec since they were sometimes running out of time at 10sec.