### PR TITLE
fix: remove `cacheDirectory` from jest config files and use default

### DIFF
--- a/jest.config.client.cjs
+++ b/jest.config.client.cjs
@@ -19,6 +19,5 @@ module.exports = {
   moduleFileExtensions: ["mjs", "js", "jsx", "ts", "tsx", "json", "node"],
   moduleNameMapper: {
     "^.+\\.(css|less|scss)$": "babel-jest"
-  },
-  cacheDirectory: "/tmp"
+  }
 };

--- a/jest.config.node.cjs
+++ b/jest.config.node.cjs
@@ -18,6 +18,5 @@ module.exports = {
   moduleFileExtensions: ["mjs", "js", "jsx", "ts", "tsx", "json", "node"],
   moduleNameMapper: {
     "^.+\\.(css|less|scss)$": "babel-jest"
-  },
-  cacheDirectory: "/tmp"
+  }
 };


### PR DESCRIPTION
The permission issue with jest's temporary cache directory due to updating the macOS Sequoia 15.7 is fixed by restarting the Terminal application.  As such setting the `cacheDirectory` in jest's configuration file in no longer necessary.