### PR TITLE
feat: update version of svg-builder to latest alpha (alpha10)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@types/node": "^22.5.1",
         "@types/serve-static": "^1.15.7",
         "@xenova/transformers": "^2.17.2",
-        "bliss-svg-builder": "^0.1.0-alpha.8",
+        "bliss-svg-builder": "^0.1.0-alpha.10",
         "express": "^4.19.2",
         "faiss-node": "^0.5.1",
         "htm": "^3.1.1",
@@ -5275,9 +5275,10 @@
       }
     },
     "node_modules/bliss-svg-builder": {
-      "version": "0.1.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/bliss-svg-builder/-/bliss-svg-builder-0.1.0-alpha.8.tgz",
-      "integrity": "sha512-BVbfQ41SJq4NCudKcyf+PkkIimuoA7uy79kpJHLpUKVx/BbPpsOqfaB76zUt0ITPrm948Vj0Gq7AzltVqTRVDA=="
+      "version": "0.1.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/bliss-svg-builder/-/bliss-svg-builder-0.1.0-alpha.10.tgz",
+      "integrity": "sha512-y4Xm5y1Pou1RhsPBBOkCDhDdgdJLCctIOk8AWz16ynlsaRoaFgyh/J/3rlvQJB4bJrvkRdWwXInFsfNqDeCKFA==",
+      "license": "MPL-2.0"
     },
     "node_modules/body-parser": {
       "version": "1.20.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/node": "^22.5.1",
     "@types/serve-static": "^1.15.7",
     "@xenova/transformers": "^2.17.2",
-    "bliss-svg-builder": "^0.1.0-alpha.8",
+    "bliss-svg-builder": "^0.1.0-alpha.10",
     "express": "^4.19.2",
     "faiss-node": "^0.5.1",
     "htm": "^3.1.1",


### PR DESCRIPTION
The latest version of the [bliss-svg-builder](https://github.com/hlridge/bliss-svg-builder) has new features for styling individual symbols within a Bliss-word and adding interactivity to individual symbols by making them a link.

This PR is updates the adaptive-palette project's package.json.