### PR TITLE
feat: update to the latest bliss-svg-builder: `0.1.0-alpha20`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@types/node": "^22.5.1",
         "@types/serve-static": "^1.15.7",
         "@xenova/transformers": "^2.17.2",
-        "bliss-svg-builder": "^0.1.0-alpha.18",
+        "bliss-svg-builder": "^0.1.0-alpha.20",
         "express": "^4.19.2",
         "faiss-node": "^0.5.1",
         "htm": "^3.1.1",
@@ -5275,9 +5275,9 @@
       }
     },
     "node_modules/bliss-svg-builder": {
-      "version": "0.1.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/bliss-svg-builder/-/bliss-svg-builder-0.1.0-alpha.18.tgz",
-      "integrity": "sha512-gP+Zt+3AWaBHssbNxLwfV61BII2LhiZjScorLamlaqXbe/W2zam0aVN2ISK32OyH2ZHD9n+rUumQtaAh69l2Iw==",
+      "version": "0.1.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/bliss-svg-builder/-/bliss-svg-builder-0.1.0-alpha.20.tgz",
+      "integrity": "sha512-7JMXK5dGhFWZkefeDcEUaTDwY9Vu53E3Rz9sbwdXHyD+tXe3utmlLhWlTMtJl23F0vwXUEoCBexEYqFNVlF9jg==",
       "license": "MPL-2.0",
       "engines": {
         "node": ">=16"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@types/node": "^22.5.1",
         "@types/serve-static": "^1.15.7",
         "@xenova/transformers": "^2.17.2",
-        "bliss-svg-builder": "^0.1.0-alpha.10",
+        "bliss-svg-builder": "^0.1.0-alpha.18",
         "express": "^4.19.2",
         "faiss-node": "^0.5.1",
         "htm": "^3.1.1",
@@ -5275,10 +5275,13 @@
       }
     },
     "node_modules/bliss-svg-builder": {
-      "version": "0.1.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/bliss-svg-builder/-/bliss-svg-builder-0.1.0-alpha.10.tgz",
-      "integrity": "sha512-y4Xm5y1Pou1RhsPBBOkCDhDdgdJLCctIOk8AWz16ynlsaRoaFgyh/J/3rlvQJB4bJrvkRdWwXInFsfNqDeCKFA==",
-      "license": "MPL-2.0"
+      "version": "0.1.0-alpha.18",
+      "resolved": "https://registry.npmjs.org/bliss-svg-builder/-/bliss-svg-builder-0.1.0-alpha.18.tgz",
+      "integrity": "sha512-gP+Zt+3AWaBHssbNxLwfV61BII2LhiZjScorLamlaqXbe/W2zam0aVN2ISK32OyH2ZHD9n+rUumQtaAh69l2Iw==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/body-parser": {
       "version": "1.20.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/node": "^22.5.1",
     "@types/serve-static": "^1.15.7",
     "@xenova/transformers": "^2.17.2",
-    "bliss-svg-builder": "^0.1.0-alpha.18",
+    "bliss-svg-builder": "^0.1.0-alpha.20",
     "express": "^4.19.2",
     "faiss-node": "^0.5.1",
     "htm": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/node": "^22.5.1",
     "@types/serve-static": "^1.15.7",
     "@xenova/transformers": "^2.17.2",
-    "bliss-svg-builder": "^0.1.0-alpha.10",
+    "bliss-svg-builder": "^0.1.0-alpha.18",
     "express": "^4.19.2",
     "faiss-node": "^0.5.1",
     "htm": "^3.1.1",

--- a/tsconfig.client.json
+++ b/tsconfig.client.json
@@ -11,8 +11,7 @@
     "jsxImportSource": "preact",
 		"resolveJsonModule": true,
     "esModuleInterop": true,
-    "alwaysStrict": true,
-    "esModuleInterop": true
+    "alwaysStrict": true
   },
   "include": [
 		"node_modules/vite/client.d.ts",

--- a/tsconfig.client.json
+++ b/tsconfig.client.json
@@ -11,7 +11,8 @@
     "jsxImportSource": "preact",
 		"resolveJsonModule": true,
     "esModuleInterop": true,
-    "alwaysStrict": true
+    "alwaysStrict": true,
+    "esModuleInterop": true
   },
   "include": [
 		"node_modules/vite/client.d.ts",


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm test` without errors
* [x] This pull request has been built by running `npm run dev` without errors
* [x] This pull request has been built by running `npm run serveAppsDemos` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

This is a simple replacement of the older `bliss-svg-builder` dependency in `package.json` with the latest alpha20 release, checking that the adaptive-palette and its demo apps function as before.

NOTE: When this work began, the version of the svg builder to use was alpha18.  There have been some bug fixes since and the version is now alpha20.  However, the name of the branch will not be updated to reflect the actual version number.
