### PR TITLE
fix: correct bliss symbols on the remove button cells

### DIFF
--- a/public/palettes/modifiers.json
+++ b/public/palettes/modifiers.json
@@ -155,8 +155,8 @@
     "remove_a_modifier-c4a69b52-e23f-4c4b-bd1b-2f5d9a4d4906": {
       "type": "ActionRemoveModifierCell",
       "options": {
-        "label": "remove added modifier",
-        "bciAvId": [ 17448, "//", 12339, ";", 8998 ],
+        "label": "undo",
+        "bciAvId": [ 23700 ],
         "rowStart": 1,
         "rowSpan": 1,
         "columnStart": 14,

--- a/public/palettes/modifiers.json
+++ b/public/palettes/modifiers.json
@@ -155,8 +155,8 @@
     "remove_a_modifier-c4a69b52-e23f-4c4b-bd1b-2f5d9a4d4906": {
       "type": "ActionRemoveModifierCell",
       "options": {
-        "label": "undo",
-        "bciAvId": [ 23700 ],
+        "label": "Undo",
+        "bciAvId": [ 17449, ";", 24670, "/", 12335, "/", 12656 ],
         "rowStart": 1,
         "rowSpan": 1,
         "columnStart": 14,

--- a/public/palettes/top_palette.json
+++ b/public/palettes/top_palette.json
@@ -131,8 +131,8 @@
     "remove-indicator-ce71d580-2712-44b8-9daf-7e894295d827": {
       "type": "ActionRemoveIndicatorCell",
       "options": {
-        "label": "remove indicator",
-        "bciAvId": [ 17448, "//", 14430, "/", 8993,  "/", 9011 ],
+        "label": "Remove indicator",
+        "bciAvId": [ 17449, ";", 24670, "//", 14430, "/", 8993,  "/", 9011 ],
         "rowStart": 1,
         "rowSpan": 1,
         "columnStart": 12,

--- a/public/palettes/top_palette.json
+++ b/public/palettes/top_palette.json
@@ -132,7 +132,7 @@
       "type": "ActionRemoveIndicatorCell",
       "options": {
         "label": "remove indicator",
-        "bciAvId": [ 17448, "//", 14430, "/", 8993,  "/", 8998 ],
+        "bciAvId": [ 17448, "//", 14430, "/", 8993,  "/", 9011 ],
         "rowStart": 1,
         "rowSpan": 1,
         "columnStart": 12,


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm test` without errors
* [x] This pull request has been tested by running `npm run lint` without errors
* [x] This pull request has been built by running `npm run dev` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

This fixes the Bliss symbols used on the "Remove indicator" button and the "Remove added modifier" button.  It also changes the label on the latter to "Undo".

