### PR TITLE
fix: upgrade bliss-svg-builder to rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@types/node": "^22.5.1",
         "@types/serve-static": "^1.15.7",
         "@xenova/transformers": "^2.17.2",
-        "bliss-svg-builder": "^0.1.0-alpha.10",
+        "bliss-svg-builder": "^1.0.0-rc.1",
         "express": "^4.19.2",
         "faiss-node": "^0.5.1",
         "htm": "^3.1.1",
@@ -93,6 +93,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
       "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -3069,6 +3070,7 @@
       "version": "0.2.31",
       "resolved": "https://registry.npmjs.org/@langchain/community/-/community-0.2.31.tgz",
       "integrity": "sha512-UayfsFyxHBLGnc9nODLupC46lvTMssYkfmFalMKqWAWQLWPEKOcDriy8Dg8+0MBME/y7SzqlCniEeEvml16hog==",
+      "peer": true,
       "dependencies": {
         "@langchain/core": ">=0.2.21 <0.3.0",
         "@langchain/openai": ">=0.2.0 <0.3.0",
@@ -4558,6 +4560,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.3.0.tgz",
       "integrity": "sha512-h53RhVyLu6AtpUzVCYLPhZGL5jzTD9fZL+SYf/+hYOx2bDkyQXztXSc4tbvKYHzfMXExMLiL9CWqJmVz6+78IQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.3.0",
         "@typescript-eslint/types": "8.3.0",
@@ -4718,6 +4721,7 @@
       "version": "2.17.2",
       "resolved": "https://registry.npmjs.org/@xenova/transformers/-/transformers-2.17.2.tgz",
       "integrity": "sha512-lZmHqzrVIkSvZdKZEx7IYY51TK0WDrC8eR0c5IMnBsO8di8are1zzw8BlLhyO2TklZKLN5UffNGs1IJwT6oOqQ==",
+      "peer": true,
       "dependencies": {
         "@huggingface/jinja": "^0.2.2",
         "onnxruntime-web": "1.14.0",
@@ -4762,6 +4766,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "devOptional": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4974,6 +4979,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
       "integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -5275,10 +5281,13 @@
       }
     },
     "node_modules/bliss-svg-builder": {
-      "version": "0.1.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/bliss-svg-builder/-/bliss-svg-builder-0.1.0-alpha.10.tgz",
-      "integrity": "sha512-y4Xm5y1Pou1RhsPBBOkCDhDdgdJLCctIOk8AWz16ynlsaRoaFgyh/J/3rlvQJB4bJrvkRdWwXInFsfNqDeCKFA==",
-      "license": "MPL-2.0"
+      "version": "1.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/bliss-svg-builder/-/bliss-svg-builder-1.0.0-rc.1.tgz",
+      "integrity": "sha512-kIdjAEnXsH/TPPXU0soWGEETRV+lhtE9bwHR5bdYZ5dr1Qdcl1jqJxZsg1nka0bDo8KhC+WJomfs5OMcEhoc4w==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/body-parser": {
       "version": "1.20.2",
@@ -5361,6 +5370,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001646",
         "electron-to-chromium": "^1.5.4",
@@ -6554,6 +6564,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.9.1.tgz",
       "integrity": "sha512-dHvhrbfr4xFQ9/dq+jcVneZMyRYLjggWjk6RVsIiHsP8Rz6yZ8LvZ//iU4TrZF+SXWG+JkNF2OyiZRvzgRDqMg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.11.0",
@@ -7011,6 +7022,7 @@
       "resolved": "https://registry.npmjs.org/faiss-node/-/faiss-node-0.5.1.tgz",
       "integrity": "sha512-zD8wobJn8C6OLWo68Unho+Ih8l6nSRB2w3Amj01a+xc4bsEvd2mBDLklAn7VocA9XO3WDvQL/bLpi5flkCn/XQ==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "node-addon-api": "^6.0.0",
@@ -7778,6 +7790,7 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "devOptional": true,
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -8476,6 +8489,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -10013,6 +10027,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
       "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "abab": "^2.0.6",
         "acorn": "^8.8.1",
@@ -10149,6 +10164,7 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/langchain/-/langchain-0.2.17.tgz",
       "integrity": "sha512-wFn7wo+XGzqYrv3KJLmMZ1M6BHx12C3YUSASOa03rcDsBzRL5onxhKAC/g4xAIqlAHrJYgU6Jb/T/S6uJ6UdkQ==",
+      "peer": true,
       "dependencies": {
         "@langchain/core": ">=0.2.21 <0.3.0",
         "@langchain/openai": ">=0.1.0 <0.3.0",
@@ -10538,7 +10554,8 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "devOptional": true
+      "devOptional": true,
+      "peer": true
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -10673,6 +10690,7 @@
       "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.13.0.tgz",
       "integrity": "sha512-Pg4nF7HlopU97ZXtrcVISWp3bdsuc5M0zXyLp2/sJv2zEMlInrau0ZKK482fQURzVezJzWBpNmu4u6vGAhij+g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "globby": "14.0.1",
         "js-yaml": "4.1.0",
@@ -11792,6 +11810,7 @@
       "version": "10.23.2",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.23.2.tgz",
       "integrity": "sha512-kKYfePf9rzKnxOAKDpsWhg/ysrHPqT+yQ7UW4JjdnqjFIeNUnNcEJvhuA8fDenxAGWzUqtd51DfVg7xp/8T9NA==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -12413,6 +12432,7 @@
       "version": "1.77.8",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
       "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
+      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -13422,6 +13442,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13642,6 +13663,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.2.tgz",
       "integrity": "sha512-dDrQTRHp5C1fTFzcSaMxjk6vdpKvT+2/mIdE07Gw2ykehT49O0z/VHS3zZ8iV/Gh8BJJKHWOe5RjaNrW5xf/GA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.41",
@@ -13936,6 +13958,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "devOptional": true,
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -14036,6 +14059,7 @@
       "version": "3.23.8",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
       "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/node": "^22.5.1",
     "@types/serve-static": "^1.15.7",
     "@xenova/transformers": "^2.17.2",
-    "bliss-svg-builder": "^0.1.0-alpha.10",
+    "bliss-svg-builder": "^1.0.0-rc.1",
     "express": "^4.19.2",
     "faiss-node": "^0.5.1",
     "htm": "^3.1.1",

--- a/setupFetchForJest.ts
+++ b/setupFetchForJest.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023-2024 Inclusive Design Research Centre, OCAD University
+ * Copyright 2023-2026 Inclusive Design Research Centre, OCAD University
  * All rights reserved.
  *
  * Licensed under the New BSD license. You may not use this file except in
@@ -19,8 +19,9 @@ import { fetch } from "whatwg-fetch";
 
 // jsdom does not expose structuredClone even though Node.js has it since v17.
 // bliss-svg-builder@1.0.0-rc.1 depends on it.  Same class of issue as fetch above.
+
+import v8 from "node:v8";
 if (typeof globalThis.structuredClone === "undefined") {
-  const v8 = require("node:v8");
   globalThis.structuredClone = (val: unknown) => v8.deserialize(v8.serialize(val));
 }
 

--- a/setupFetchForJest.ts
+++ b/setupFetchForJest.ts
@@ -17,6 +17,13 @@
 
 import { fetch } from "whatwg-fetch";
 
+// jsdom does not expose structuredClone even though Node.js has it since v17.
+// bliss-svg-builder@1.0.0-rc.1 depends on it.  Same class of issue as fetch above.
+if (typeof globalThis.structuredClone === "undefined") {
+  const v8 = require("node:v8");
+  globalThis.structuredClone = (val: unknown) => v8.deserialize(v8.serialize(val));
+}
+
 module.exports = {
   globals: {
     fetch: fetch


### PR DESCRIPTION
## Summary
- Upgrades `bliss-svg-builder` from `^0.1.0-alpha.10` to `^1.0.0-rc.1`
- No application code changes. The rc.1 API is backward-compatible for the constructor, `.svgCode`, and `.svgElement` usage in this project
- Adds a `structuredClone` polyfill to the Jest setup file: `bliss-svg-builder@rc.1` uses `structuredClone` internally, which Node.js has had since v17 but Jest's jsdom environment does not expose, the same class of issue that already required a `fetch` polyfill in `setupFetchForJest.ts`